### PR TITLE
feat(app): support bind pid

### DIFF
--- a/cmd/ovm/main.go
+++ b/cmd/ovm/main.go
@@ -91,6 +91,12 @@ func main() {
 	}
 
 	g.Go(func() error {
+		waitBindPID(ctx, log, opt.BindPID)
+		cancel()
+		return nil
+	})
+
+	g.Go(func() error {
 		return gvproxy.Run(ctx, g, opt)
 	})
 

--- a/cmd/ovm/wait_bind_pid.go
+++ b/cmd/ovm/wait_bind_pid.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2024 OOMOL, Inc. <https://www.oomol.com>
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/oomol-lab/ovm/pkg/logger"
+	"github.com/oomol-lab/ovm/pkg/utils"
+)
+
+func waitBindPID(ctx context.Context, log *logger.Context, pid int) {
+	if pid == 0 {
+		log.Info("pid is 0, no need to wait")
+		<-ctx.Done()
+		return
+	}
+
+	log.Infof("wait bind pid: %d exit", pid)
+
+	for {
+		if ctx.Err() != nil {
+			log.Info("cancel wait bind pid, because context done")
+			return
+		}
+
+		if !utils.ProcessExists(pid) {
+			log.Infof("bind pid: %d exited", pid)
+			return
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -21,6 +21,7 @@ var (
 	targetPath string
 	versions   string
 	cliMode    bool
+	bindPID    int
 )
 
 func Parse() {
@@ -36,6 +37,7 @@ func Parse() {
 	flag.StringVar(&targetPath, "target-path", "", "Store disk images and kernel/initrd/rootfs files")
 	flag.StringVar(&versions, "versions", "", "Set version")
 	flag.BoolVar(&cliMode, "cli", false, "Run in CLI mode")
+	flag.IntVar(&bindPID, "bind-pid", 0, "OVM will exit when the bound pid exited")
 
 	flag.Parse()
 

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -26,6 +26,7 @@ type Context struct {
 	IsCliMode      bool
 	LockFile       string
 	ExecutablePath string
+	BindPID        int
 
 	Endpoint          string
 	SSHPort           int
@@ -106,6 +107,7 @@ func (c *Context) basic() error {
 	c.CPUS = cpus
 	c.MemoryBytes = memory * 1024 * 1024
 	c.IsCliMode = cliMode
+	c.BindPID = bindPID
 
 	if err := os.MkdirAll("/tmp/ovm", 0755); err != nil {
 		return err


### PR DESCRIPTION
When the bound pid exits, the ovm also needs to exit.

Because there is a possibility that the app sets detached when launching ovm, at this time ppid will be 1 (ovm becomes a zombie process). In order to avoid this situation, we need users to explicitly pass in the current app's pid. Avoid the problem of residual processes.