### PR TITLE
fix(version): cannot start when the version.json format is incorrect

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -32,7 +32,12 @@ func (l *List) Read() error {
 		return err
 	}
 
-	return json.Unmarshal(data, &l)
+	if err := json.Unmarshal(data, &l); err != nil {
+		// delete and rebuild when file parsing fails.
+		return os.RemoveAll(l.versionPath)
+	}
+
+	return nil
 }
 
 func (l *List) Write() error {


### PR DESCRIPTION
When encountering an error while parsing version.json, delete and recreate it.