### PR TITLE
fix(vm): kernel incorrectly believes that tsc is unreliable in amd64

### DIFF
--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -29,6 +29,8 @@ words:
   - pidlock
   - gopsutil
   - shirou
+  - clocksource
+  - hpet
 dictionaries:
   - companies
   - softwareTerms

--- a/internal/consts/consts_amd64.go
+++ b/internal/consts/consts_amd64.go
@@ -1,0 +1,3 @@
+package consts
+
+const IsAMD64 = true

--- a/internal/consts/consts_arm64.go
+++ b/internal/consts/consts_arm64.go
@@ -1,0 +1,3 @@
+package consts
+
+const IsAMD64 = false

--- a/pkg/vfkit/kernel_cmd.go
+++ b/pkg/vfkit/kernel_cmd.go
@@ -6,6 +6,7 @@ package vfkit
 import (
 	"strings"
 
+	"github.com/oomol-lab/ovm/internal/consts"
 	"github.com/oomol-lab/ovm/pkg/cli"
 )
 
@@ -20,6 +21,14 @@ func kernelCMD(opt *cli.Context) string {
 	// disable the creation of useless network interfaces.
 	// see: https://github.com/oomol-lab/ovm-js/pull/23
 	sb.WriteString("fb_tunnels=none ")
+
+	// When a Mac wakes up from sleep, the hardware clock in the guest will lag for a while. This causes the kernel to think that the TSC is unstable, and thus switches to HPET.
+	// However, the HPET is much slower than the TSC, causing any program involved with time-related code to experience a drop in performance.
+	// Don't worry about any side effects of this option. In PR #19, we forced an update of the system time and hardware time in the guest.
+	// In arm64, the clocksource is fixed as arch_sys_counter, so this issue does not exist.
+	if consts.IsAMD64 {
+		sb.WriteString("clocksource=tsc tsc=reliable ")
+	}
 
 	// systemd configuration
 	// see: https://www.freedesktop.org/software/systemd/man/latest/systemd.html#Options%20that%20duplicate%20kernel%20command%20line%20settings


### PR DESCRIPTION
When a Mac wakes up from sleep, the hardware clock in the guest will lag for a while. This causes the kernel to think that the `TSC` is unstable, and thus switches to `HPET`.
However, the `HPET` is much slower than the `TSC`, causing any program involved with time-related code to experience a drop in performance.
Don't worry about any side effects of this option. In PR #19, we forced an update of the system time and hardware time in the guest.
In arm64, the `clocksource` is fixed as `arch_sys_counter`, so this issue does not exist.