### PR TITLE
refactor(cli): remove time-sync param

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -23,7 +23,6 @@ var (
 	eventSocketPath string
 	cliMode         bool
 	bindPID         int
-	timeSync        bool
 )
 
 func Parse() {
@@ -41,7 +40,6 @@ func Parse() {
 	flag.StringVar(&eventSocketPath, "event-socket-path", "", "Send event to this socket")
 	flag.BoolVar(&cliMode, "cli", false, "Run in CLI mode")
 	flag.IntVar(&bindPID, "bind-pid", 0, "OVM will exit when the bound pid exited")
-	flag.BoolVar(&timeSync, "time-sync", true, "Sync time when the virtual machine is awake")
 
 	flag.Parse()
 

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -27,7 +27,6 @@ type Context struct {
 	ExecutablePath  string
 	BindPID         int
 	EventSocketPath string
-	TimeSync        bool
 
 	Endpoint          string
 	SSHPort           int
@@ -84,7 +83,6 @@ func (c *Context) basic() error {
 	c.IsCliMode = cliMode
 	c.BindPID = bindPID
 	c.EventSocketPath = eventSocketPath
-	c.TimeSync = timeSync
 
 	if err := os.MkdirAll("/tmp/ovm", 0755); err != nil {
 		return err

--- a/pkg/powermonitor/powermonitor.go
+++ b/pkg/powermonitor/powermonitor.go
@@ -33,7 +33,7 @@ func Setup(ctx context.Context, g *errgroup.Group, opt *cli.Context, log *logger
 
 	g.Go(func() error {
 		for activity := range ch {
-			if activity.Type == notifier.Awake && opt.TimeSync {
+			if activity.Type == notifier.Awake {
 				log.Info("start sync time")
 				if err := syncTime(); err != nil {
 					return fmt.Errorf("sync time failed: %w", err)


### PR DESCRIPTION
I can't imagine a scenario where I wouldn't turn it on. The cost of not turning it on would be that the guest clock would be incorrect (relying on chrony sync is too slow), so force it on :)