### PR TITLE
feat(vm): sync time when vm state is resume

### DIFF
--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -3,9 +3,12 @@
 
 package channel
 
+import "github.com/Code-Hex/go-infinity-channel"
+
 type _context struct {
 	gvproxyReady chan bool
 	vmReady      chan bool
+	syncTime     *infinity.Channel[bool]
 }
 
 var c *_context
@@ -14,12 +17,14 @@ func init() {
 	c = &_context{
 		gvproxyReady: make(chan bool, 1),
 		vmReady:      make(chan bool, 1),
+		syncTime:     infinity.NewChannel[bool](),
 	}
 }
 
 func Close() {
 	close(c.gvproxyReady)
 	close(c.vmReady)
+	c.syncTime.Close()
 }
 
 func NotifyGVProxyReady() {
@@ -36,4 +41,12 @@ func NotifyVMReady() {
 
 func ReceiveVMReady() <-chan bool {
 	return c.vmReady
+}
+
+func NotifySyncTime() {
+	c.syncTime.In() <- true
+}
+
+func ReceiveSyncTime() <-chan bool {
+	return c.syncTime.Out()
 }

--- a/pkg/powermonitor/powermonitor.go
+++ b/pkg/powermonitor/powermonitor.go
@@ -5,8 +5,8 @@ package powermonitor
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/oomol-lab/ovm/pkg/channel"
 	"github.com/oomol-lab/ovm/pkg/cli"
 	"github.com/oomol-lab/ovm/pkg/logger"
 	"github.com/prashantgupta24/mac-sleep-notifier/notifier"
@@ -34,10 +34,7 @@ func Setup(ctx context.Context, g *errgroup.Group, opt *cli.Context, log *logger
 	g.Go(func() error {
 		for activity := range ch {
 			if activity.Type == notifier.Awake {
-				log.Info("start sync time")
-				if err := syncTime(); err != nil {
-					return fmt.Errorf("sync time failed: %w", err)
-				}
+				channel.NotifySyncTime()
 			}
 		}
 


### PR DESCRIPTION
After the virtual machine resumes from the pause, we need to synchronize the time, as the time in the VM is inaccurate now.
Here, we are listening to `VirtualMachineStateResuming`, as there's no `VirtualMachineStateResume` state.
And the VM progresses from `VirtualMachineStateResuming` to `VirtualMachineStateRunning` quite rapidly, even if it's slow, the request to synchronize time won't fail but will be piled up at the sender's end, until the other end recovers.