### PR TITLE
refactor(tiemsync): add `--verbose` param to hwclock

### DIFF
--- a/pkg/powermonitor/timesync.go
+++ b/pkg/powermonitor/timesync.go
@@ -61,7 +61,7 @@ func initTimeSync(ctx context.Context, g *errgroup.Group, socketPath string, log
 
 			log.Info("start sync time")
 
-			command := []byte(fmt.Sprintf("date -s @%d && hwclock -w", time.Now().Unix()))
+			command := []byte(fmt.Sprintf("date -s @%d && hwclock -w --verbose", time.Now().Unix()))
 			length := len(command)
 			header := make([]byte, 2)
 			binary.LittleEndian.PutUint16(header, uint16(length))


### PR DESCRIPTION
In case of failure of hwclock, we can see more logs.

Additional Log:

```
[ 2535.080346] vsock_guest_exec[1699]: Tue Jan 23 16:45:39 CST 2024
[ 2535.080996] vsock_guest_exec[1698]: hwclock: Cannot access the Hardware Clock via any known method.
[ 2535.081121] vsock_guest_exec[1698]: hwclock: Use the --verbose option to see the details of our search for an access method.
[ 2536.125404] fstrim[1701]: /var/lib/containers: 8 TiB (8793077772288 bytes) trimmed on /dev/vdc
[ 2563.233153] vsock_guest_exec[1708]: Tue Jan 23 17:20:00 CST 2024
[ 2563.234392] vsock_guest_exec[1707]: hwclock: Cannot access the Hardware Clock via any known method.
[ 2563.234768] vsock_guest_exec[1707]: hwclock: Use the --verbose option to see the details of our search for an access method.
[ 5743.524078] vsock_guest_exec[1756]: Tue Jan 23 18:14:38 CST 2024
[ 5743.527059] vsock_guest_exec[1755]: hwclock: Cannot access the Hardware Clock via any known method.
[ 5743.528284] vsock_guest_exec[1755]: hwclock: Use the --verbose option to see the details of our search for an access method.
[ 5750.052241] BUG: Bad rss-counter state mm:00000000df6ab273 type:MM_ANONPAGES val:4
[ 5750.056212] systemd[1]: systemd-journald.service: Scheduled restart job, restart counter is at 1.
[ 5750.056547] systemd[1]: Journal Audit Socket was skipped because of an unmet condition check (ConditionSecurity=audit).
[ 5750.058424] Unable to handle kernel NULL pointer dereference at virtual address 0000000000000000
[ 5750.058479] Mem abort info:
[ 5750.058490]   ESR = 0x0000000096000004
[ 5750.058511]   EC = 0x25: DABT (current EL), IL = 32 bits
[ 5750.058539]   SET = 0, FnV = 0
[ 5750.058561]   EA = 0, S1PTW = 0
[ 5750.058579]   FSC = 0x04: level 0 translation fault
[ 5750.058606] Data abort info:
[ 5750.058616]   ISV = 0, ISS = 0x00000004
[ 5750.058631]   CM = 0, WnR = 0
[ 5750.058652] user pgtable: 4k pages, 48-bit VAs, pgdp=0000000104d9a000
[ 5750.058680] [0000000000000000] pgd=0000000000000000, p4d=0000000000000000
[ 5750.058715] Internal error: Oops: 0000000096000004 [#1] SMP
[ 5750.058747] Modules linked in:
[ 5750.058778] CPU: 2 PID: 1 Comm: systemd Not tainted 6.1.50 #3
[ 5750.058814] pstate: 60400005 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[ 5750.058849] pc : __bpf_prog_put.constprop.0+0xc/0xb0
[ 5750.058914] lr : bpf_prog_release+0x14/0x24
[ 5750.058958] sp : ffff800009a1bca0
[ 5750.059004] x29: ffff800009a1bca0 x28: 0000000000000004 x27: 0000000000000000
[ 5750.059061] x26: 0000000000000000 x25: 0000000000000000 x24: 0000000000000000
[ 5750.059096] x23: ffff0000c05fb000 x22: ffff0000c0124f20 x21: ffff0000c049d110
[ 5750.059198] x20: 00000000000e0003 x19: ffff0000c1b4c500 x18: ffff8000099e5038
[ 5750.059285] x17: 0000000000000000 x16: 0000000000000000 x15: 0000000000000000
[ 5750.059342] x14: 0000000000000000 x13: 0000000000000000 x12: 0000000000000000
[ 5750.059403] x11: 0000000000000000 x10: 0000000000000000 x9 : 0000000000000000
[ 5750.059458] x8 : ffff800009a1bde8 x7 : 0000000000000000 x6 : 000000000000003f
[ 5750.059525] x5 : ffff0000c049d110 x4 : 0000000000000000 x3 : ffff0000c05fb000
[ 5750.059596] x2 : ffff80000816cb80 x1 : ffffffffffffffff x0 : 0000000000000000
[ 5750.059667] Call trace:
[ 5750.059683]  __bpf_prog_put.constprop.0+0xc/0xb0
[ 5750.059728]  __fput+0x78/0x260
[ 5750.059767]  ____fput+0x10/0x20
[ 5750.059793]  task_work_run+0x80/0xe0
[ 5750.059837]  do_notify_resume+0x204/0x11d0
[ 5750.059870]  el0_svc+0xd4/0xe4
[ 5750.059917]  el0t_64_sync_handler+0x114/0x120
[ 5750.059952]  el0t_64_sync+0x180/0x184
[ 5750.059986] Code: d503201f f9401c00 d503201f 92800001 (f8e10001) 
[ 5750.060048] ---[ end trace 0000000000000000 ]---
[ 5750.060203] Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b
[ 5750.060289] SMP: stopping secondary CPUs
[ 5750.060339] Kernel Offset: disabled
[ 5750.060362] CPU features: 0x00000,00050095,66927723
[ 5750.060378] Memory Limit: none
[ 5750.060390] ---[ end Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b ]---

```