### PR TITLE
refactor(timesync): remove hwclock

### DIFF
--- a/pkg/powermonitor/timesync.go
+++ b/pkg/powermonitor/timesync.go
@@ -61,7 +61,7 @@ func initTimeSync(ctx context.Context, g *errgroup.Group, socketPath string, log
 
 			log.Info("start sync time")
 
-			command := []byte(fmt.Sprintf("date -s @%d && hwclock -w --verbose", time.Now().Unix()))
+			command := []byte(fmt.Sprintf("date -s @%d", time.Now().Unix()))
 			length := len(command)
 			header := make([]byte, 2)
 			binary.LittleEndian.PutUint16(header, uint16(length))

--- a/pkg/vfkit/ignition.go
+++ b/pkg/vfkit/ignition.go
@@ -30,7 +30,7 @@ func cmd(opt *cli.Context) (string, error) {
 
 	mount := fmt.Sprintf("echo -e %s >> /mnt/overlay/etc/fstab", fstab)
 	authorizedKeys := fmt.Sprintf("mkdir -p /mnt/overlay/root/.ssh; echo %s >> /mnt/overlay/root/.ssh/authorized_keys", opt.SSHPublicKey)
-	ready := fmt.Sprintf("echo -e \"date -s @%d;hwclock -w;\\\\necho Ready | socat - VSOCK-CONNECT:2:1026\" > /mnt/overlay/opt/ready.command", time.Now().Unix())
+	ready := fmt.Sprintf("echo -e \"date -s @%d;\\\\necho Ready | socat - VSOCK-CONNECT:2:1026\" > /mnt/overlay/opt/ready.command", time.Now().Unix())
 
 	return fmt.Sprintf("%s; %s; %s; %s", mount, authorizedKeys, ready, tz), nil
 }


### PR DESCRIPTION
In our scenario, I can't currently envision the necessity of synchronizing hardware time. So let's remove it for now and reconsider if issues arise in the future.