### PR TITLE
feat(kernel): add `-kernel-debug` param in cli

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -24,6 +24,7 @@ var (
 	cliMode         bool
 	bindPID         int
 	powerSaveMode   bool
+	kernelDebug     bool
 )
 
 func Parse() {
@@ -42,6 +43,7 @@ func Parse() {
 	flag.BoolVar(&cliMode, "cli", false, "Run in CLI mode")
 	flag.IntVar(&bindPID, "bind-pid", 0, "OVM will exit when the bound pid exited")
 	flag.BoolVar(&powerSaveMode, "power-save-mode", false, "Enable power save mode")
+	flag.BoolVar(&kernelDebug, "kernel-debug", false, "Enable kernel debug")
 
 	flag.Parse()
 

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -28,6 +28,7 @@ type Context struct {
 	BindPID         int
 	EventSocketPath string
 	PowerSaveMode   bool
+	KernelDebug     bool
 
 	Endpoint          string
 	SSHPort           int
@@ -86,6 +87,7 @@ func (c *Context) basic() error {
 	c.BindPID = bindPID
 	c.EventSocketPath = eventSocketPath
 	c.PowerSaveMode = powerSaveMode
+	c.KernelDebug = kernelDebug
 
 	if err := os.MkdirAll("/tmp/ovm", 0755); err != nil {
 		return err

--- a/pkg/vfkit/kernel_cmd.go
+++ b/pkg/vfkit/kernel_cmd.go
@@ -43,8 +43,7 @@ func kernelCMD(opt *cli.Context) string {
 		sb.WriteString("systemd.default_standard_error=journal+console ")
 	}
 
-	// enable debug logs
-	if opt.IsCliMode {
+	if opt.KernelDebug {
 		sb.WriteString("debug ")
 	}
 


### PR DESCRIPTION
Sometimes, kernel debug logs are needed even in non-cli scenarios, so it is not possible to enable them directly based on whether the mode is cli or not. Add a parameter to decide whether to enable kernel debug or not.